### PR TITLE
Memory Bank Controller 1

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.1.0",
+    "command": "cmd",
+    "isShellCommand": true,
+    "showOutput": "always",
+    "echoCommand": true,
+    "suppressTaskName": true,
+    "args": [
+        "/C"
+    ],
+    "tasks": []
+}

--- a/src/gameboy/cartridge.rs
+++ b/src/gameboy/cartridge.rs
@@ -1,4 +1,7 @@
+use std::ops::{Deref, DerefMut};
+
 use gameboy::interconnect::Interconnect;
+use gameboy::mbc::{MBC, MBC0};
 use gameboy::Memory;
 
 const CART_MEM_SIZE: usize = 0x200000;
@@ -6,36 +9,56 @@ const CART_RAM_SIZE: usize = 0x8000;
 
 pub struct CartridgeDetails {
     pub game_title: String,
+    pub cartridge_type: u8,
 }
 
 pub struct Cartridge {
     rom_code_size: usize,
-    pub rom: Memory,
-    pub ram: Memory,
+    pub mbc: Box<MBC>,
+    pub details: CartridgeDetails,
 }
 
 impl Cartridge {
-    pub fn new() -> Cartridge {
-        Cartridge {
-            rom_code_size: 0x00,
-            rom: Memory::new(CART_MEM_SIZE),
-            ram: Memory::new(CART_RAM_SIZE),
-        }
-    }
-
     pub fn with_rom(rom: Vec<u8>) -> Cartridge {
-        let mut r = Memory::new(CART_MEM_SIZE);
-        r.write_bytes(0x00, &rom);
+        let details = Self::get_details(&rom);
+        let cartridge_type = rom[0x147];
+        let mbc = Self::get_controller(cartridge_type, &rom);
 
         Cartridge {
             rom_code_size: rom.len(),
-            rom: r,
-            ram: Memory::new(CART_RAM_SIZE),
+            mbc: mbc,
+            details: details,
         }
     }
 
-    pub fn details(&self, interconnect: &Interconnect) -> CartridgeDetails {
-        let game_title = String::from_utf8_lossy(&self.rom[0x134..0x142]).into();
-        CartridgeDetails { game_title: game_title }
+    pub fn get_details(rom: &[u8]) -> CartridgeDetails {
+        let game_title = String::from_utf8_lossy(&rom[0x134..0x142]).into();
+        let cartridge_type = rom[0x147];
+
+        CartridgeDetails {
+            game_title: game_title,
+            cartridge_type: cartridge_type,
+        }
+    }
+
+    fn get_controller(b: u8, rom: &[u8]) -> Box<MBC> {
+        match b {
+            0x00 => Box::new(MBC0::new(rom)),
+            _ => panic!("MBC not supported"),
+        }
+    }
+}
+
+impl Deref for Cartridge {
+    type Target = Box<MBC>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mbc
+    }
+}
+
+impl DerefMut for Cartridge {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mbc
     }
 }

--- a/src/gameboy/cartridge.rs
+++ b/src/gameboy/cartridge.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use gameboy::interconnect::Interconnect;
-use gameboy::mbc::{MBC, MBC0};
+use gameboy::mbc::{MBC, MBC0, MBC1};
 use gameboy::Memory;
 
 const CART_MEM_SIZE: usize = 0x200000;
@@ -44,6 +44,7 @@ impl Cartridge {
     fn get_controller(b: u8, rom: &[u8]) -> Box<MBC> {
         match b {
             0x00 => Box::new(MBC0::new(rom)),
+            0x01...0x03 => Box::new(MBC1::new(rom)),
             _ => panic!("MBC not supported"),
         }
     }

--- a/src/gameboy/cpu.rs
+++ b/src/gameboy/cpu.rs
@@ -164,7 +164,8 @@ impl Cpu {
             let mut cycles = opcode.cycles;
             let operand = self.get_operand_from_opcode(interconnect, &opcode);
 
-            // println!("Read 0x{:02X} from 0x{:04X}", byte, self.registers.pc);
+            println!("Read 0x{:02X} from 0x{:04X}", byte, self.registers.pc);
+
             self.registers.pc += opcode.length;
 
             match opcode.code {

--- a/src/gameboy/cpu.rs
+++ b/src/gameboy/cpu.rs
@@ -164,7 +164,7 @@ impl Cpu {
             let mut cycles = opcode.cycles;
             let operand = self.get_operand_from_opcode(interconnect, &opcode);
 
-            println!("Read 0x{:02X} from 0x{:04X}", byte, self.registers.pc);
+            // println!("Read 0x{:02X} from 0x{:04X}", byte, self.registers.pc);
             let pc = self.registers.pc;
             self.registers.pc += opcode.length;
 
@@ -421,11 +421,6 @@ impl Cpu {
                                        opcode.code,
                                        self.registers.pc))
                 }
-            }
-
-
-            if pc == 0x4B36 {
-                panic!("{:?}", operand);
             }
 
             return Ok(cycles);
@@ -1354,7 +1349,6 @@ impl Cpu {
     fn call(&mut self, addr: u16, interconnect: &mut Interconnect) {
         self.registers.sp -= 0x02;
         interconnect.write_u16(self.registers.sp as u16, self.registers.pc);
-        println!("Calling {:04X}", addr);
         self.registers.pc = addr;
     }
 

--- a/src/gameboy/cpu.rs
+++ b/src/gameboy/cpu.rs
@@ -165,7 +165,7 @@ impl Cpu {
             let operand = self.get_operand_from_opcode(interconnect, &opcode);
 
             println!("Read 0x{:02X} from 0x{:04X}", byte, self.registers.pc);
-
+            let pc = self.registers.pc;
             self.registers.pc += opcode.length;
 
             match opcode.code {
@@ -421,6 +421,11 @@ impl Cpu {
                                        opcode.code,
                                        self.registers.pc))
                 }
+            }
+
+
+            if pc == 0x4B36 {
+                panic!("{:?}", operand);
             }
 
             return Ok(cycles);
@@ -1349,6 +1354,7 @@ impl Cpu {
     fn call(&mut self, addr: u16, interconnect: &mut Interconnect) {
         self.registers.sp -= 0x02;
         interconnect.write_u16(self.registers.sp as u16, self.registers.pc);
+        println!("Calling {:04X}", addr);
         self.registers.pc = addr;
     }
 

--- a/src/gameboy/gameboy.rs
+++ b/src/gameboy/gameboy.rs
@@ -28,7 +28,7 @@ impl GameBoy {
         self.cpu.reset(&mut self.interconnect);
     }
 
-    pub fn cart_details(&self) -> CartridgeDetails {
+    pub fn cart_details(&self) -> &CartridgeDetails {
         self.interconnect.cart_details()
     }
 

--- a/src/gameboy/mbc/mbc.rs
+++ b/src/gameboy/mbc/mbc.rs
@@ -1,0 +1,34 @@
+use std::ops::Range;
+
+use byteorder::{ByteOrder, LittleEndian};
+
+pub trait MBC {
+    fn read_ram_u8(&self, addr: u16) -> u8;
+    fn read_rom_u8(&self, addr: u16) -> u8;
+
+    fn read_ram_u16(&self, addr: u16) -> u16 {
+        let a = self.read_ram_u8(addr);
+        let b = self.read_ram_u8(addr + 0x01);
+
+        LittleEndian::read_u16(&[a, b])
+    }
+
+    fn read_rom_u16(&self, addr: u16) -> u16 {
+        let a = self.read_rom_u8(addr);
+        let b = self.read_rom_u8(addr + 0x01);
+
+        LittleEndian::read_u16(&[a, b])
+    }
+
+    fn write_ram_u8(&mut self, addr: u16, b: u8);
+    fn write_rom_u8(&mut self, addr: u16, b: u8);
+}
+
+pub fn get_ram_size(b: u8) -> usize {
+    match b {
+        0x01 => 0x800,      // 2KB (2048 bytes)
+        0x02 => 0x2000,     // 8KB (8096 bytes)
+        0x03 => 0x8000,     // 32KB
+        _ => 0x00,
+    }
+}

--- a/src/gameboy/mbc/mbc.rs
+++ b/src/gameboy/mbc/mbc.rs
@@ -22,6 +22,8 @@ pub trait MBC {
 
     fn write_ram_u8(&mut self, addr: u16, b: u8);
     fn write_rom_u8(&mut self, addr: u16, b: u8);
+
+    fn write_ram_u16(&mut self, addr: u16, b: u16);
 }
 
 pub fn get_ram_size(b: u8) -> usize {

--- a/src/gameboy/mbc/mbc0.rs
+++ b/src/gameboy/mbc/mbc0.rs
@@ -1,0 +1,51 @@
+
+// MBC0 - no memory banking
+
+use std::ops::Range;
+
+use gameboy::Memory;
+use gameboy::mbc::mbc::get_ram_size;
+use gameboy::mbc::MBC;
+
+pub struct MBC0 {
+    pub rom: Memory,
+    pub ram: Memory,
+}
+
+impl MBC0 {
+    pub fn new(rom: &[u8]) -> MBC0 {
+        let mut r = Memory::new(rom.len());
+        r.write_bytes(0x00, rom);
+
+        let ram_size = get_ram_size(rom[0x149]);
+        let ram = Memory::new(ram_size);
+
+        MBC0 { rom: r, ram: ram }
+    }
+}
+
+impl MBC for MBC0 {
+    fn read_ram_u8(&self, addr: u16) -> u8 {
+        self.ram[addr as usize]
+    }
+
+    fn read_rom_u8(&self, addr: u16) -> u8 {
+        self.rom[addr as usize]
+    }
+
+    fn read_ram_u16(&self, addr: u16) -> u16 {
+        self.ram.read_u16(addr)
+    }
+
+    fn read_rom_u16(&self, addr: u16) -> u16 {
+        self.rom.read_u16(addr)
+    }
+
+    fn write_ram_u8(&mut self, addr: u16, b: u8) {
+        ()
+    }
+
+    fn write_rom_u8(&mut self, addr: u16, b: u8) {
+        ()
+    }
+}

--- a/src/gameboy/mbc/mbc0.rs
+++ b/src/gameboy/mbc/mbc0.rs
@@ -48,4 +48,8 @@ impl MBC for MBC0 {
     fn write_rom_u8(&mut self, addr: u16, b: u8) {
         ()
     }
+
+    fn write_ram_u16(&mut self, addr: u16, b: u16) {
+        self.ram.write_u16(addr, b)
+    }
 }

--- a/src/gameboy/mbc/mbc1.rs
+++ b/src/gameboy/mbc/mbc1.rs
@@ -65,18 +65,15 @@ impl MBC for MBC1 {
     }
 
     fn read_rom_u16(&self, addr: u16) -> u16 {
-        println!("Reading u16 from ROM Bank: {}", self.rom_bank);
         let addr = if addr < 0x4000 {
-            addr
+            addr as usize
         } else {
-            self.rom_bank as u16 * 0x4000 | (addr & 0x3FFF)
+            self.rom_bank as usize * 0x4000 + (addr as usize - 0x4000)
         };
 
-        let addr = addr as usize;
         let a = self.rom[addr] as u16;
         let b = self.rom[addr + 0x01] as u16;
         let result = (b << 0x08) | a;
-        println!("Read result: {:04X}", result);
         result
     }
 

--- a/src/gameboy/mbc/mbc1.rs
+++ b/src/gameboy/mbc/mbc1.rs
@@ -1,0 +1,68 @@
+
+use std::ops::Range;
+
+use gameboy::Memory;
+use gameboy::mbc::mbc::get_ram_size;
+use gameboy::mbc::MBC;
+
+pub struct MBC1 {
+    pub rom: Memory,
+    pub ram: Memory,
+    ram_enabled: bool,
+}
+
+impl MBC1 {
+    pub fn new(rom: &[u8]) -> MBC1 {
+        let mut r = Memory::new(rom.len());
+        r.write_bytes(0x00, rom);
+
+        let ram_size = get_ram_size(rom[0x149]);
+        let ram = Memory::new(ram_size);
+
+        MBC1 {
+            rom: r,
+            ram: ram,
+            ram_enabled: true,
+        }
+    }
+}
+
+impl MBC for MBC1 {
+    fn read_ram_u8(&self, addr: u16) -> u8 {
+        if !self.ram_enabled {
+            return 0xFF;
+        }
+        self.ram[addr as usize]
+    }
+
+    fn read_rom_u8(&self, addr: u16) -> u8 {
+        self.rom[addr as usize]
+    }
+
+    fn read_ram_u16(&self, addr: u16) -> u16 {
+        if !self.ram_enabled {
+            return 0xFFFF;
+        }
+        self.ram.read_u16(addr)
+    }
+
+    fn read_rom_u16(&self, addr: u16) -> u16 {
+        self.rom.read_u16(addr)
+    }
+
+    fn write_ram_u8(&mut self, addr: u16, b: u8) {
+        if !self.ram_enabled {
+            ()
+        }
+    }
+
+    fn write_rom_u8(&mut self, addr: u16, b: u8) {
+        match addr {
+            0x0000...0x1FFF => self.ram_enabled = b & 0x0F == 0x0A,
+            _ => {
+                panic!("Unsupported address range in Memory Bank Controller 1: {:04X}",
+                       addr)
+            }
+        }
+    }
+}

--- a/src/gameboy/mbc/mbc1.rs
+++ b/src/gameboy/mbc/mbc1.rs
@@ -5,10 +5,19 @@ use gameboy::Memory;
 use gameboy::mbc::mbc::get_ram_size;
 use gameboy::mbc::MBC;
 
+pub enum BankMode {
+    RomBanking,
+    RamBanking,
+}
+
 pub struct MBC1 {
     pub rom: Memory,
     pub ram: Memory,
+
     ram_enabled: bool,
+    rom_bank: usize,
+    ram_bank: usize,
+    bank_mode: BankMode,
 }
 
 impl MBC1 {
@@ -23,6 +32,9 @@ impl MBC1 {
             rom: r,
             ram: ram,
             ram_enabled: true,
+            rom_bank: 0x00,
+            ram_bank: 0x00,
+            bank_mode: BankMode::RomBanking,
         }
     }
 }
@@ -36,7 +48,13 @@ impl MBC for MBC1 {
     }
 
     fn read_rom_u8(&self, addr: u16) -> u8 {
-        self.rom[addr as usize]
+        let addr = if addr < 0x4000 {
+            addr as usize
+        } else {
+            self.rom_bank * 0x4000 | (addr as usize & 0x3FFF)
+        };
+
+        self.rom[addr]
     }
 
     fn read_ram_u16(&self, addr: u16) -> u16 {
@@ -59,10 +77,33 @@ impl MBC for MBC1 {
     fn write_rom_u8(&mut self, addr: u16, b: u8) {
         match addr {
             0x0000...0x1FFF => self.ram_enabled = b & 0x0F == 0x0A,
+            0x2000...0x3FFF => {
+                let b = if b & 0x1F == 0x00 { 0x01 } else { b };
+                self.rom_bank = (self.rom_bank & 0x60) | b as usize;
+            }
+            0x4000...0x5FFF => {
+                if let BankMode::RomBanking = self.bank_mode {
+                    self.rom_bank = self.rom_bank & 0x1F | (((b as usize) & 0x03) << 0x05);
+                }
+            }
+            0x6000...0x7FFF => {
+                self.bank_mode = if b & 0x01 == 0x01 {
+                    BankMode::RamBanking
+                } else {
+                    BankMode::RomBanking
+                };
+            }
             _ => {
                 panic!("Unsupported address range in Memory Bank Controller 1: {:04X}",
                        addr)
             }
         }
+    }
+
+    fn write_ram_u16(&mut self, addr: u16, b: u16) {
+        if !self.ram_enabled {
+            ()
+        }
+        self.ram.write_u16(addr, b)
     }
 }

--- a/src/gameboy/mbc/mod.rs
+++ b/src/gameboy/mbc/mod.rs
@@ -1,6 +1,8 @@
 
 mod mbc;
 mod mbc0;
+mod mbc1;
 
 pub use self::mbc::MBC;
 pub use self::mbc0::MBC0;
+pub use self::mbc1::MBC1;

--- a/src/gameboy/mbc/mod.rs
+++ b/src/gameboy/mbc/mod.rs
@@ -1,0 +1,6 @@
+
+mod mbc;
+mod mbc0;
+
+pub use self::mbc::MBC;
+pub use self::mbc0::MBC0;

--- a/src/gameboy/memory.rs
+++ b/src/gameboy/memory.rs
@@ -1,7 +1,7 @@
 use std;
 use std::fs::File;
 use std::io::Write;
-use std::ops::{Deref, Range};
+use std::ops::{Deref, DerefMut, Range};
 use std::path::Path;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -61,5 +61,11 @@ impl Deref for Memory {
 
     fn deref(&self) -> &[u8] {
         &self.ram
+    }
+}
+
+impl DerefMut for Memory {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.ram
     }
 }

--- a/src/gameboy/mod.rs
+++ b/src/gameboy/mod.rs
@@ -9,6 +9,7 @@ mod gpu;
 mod interconnect;
 mod irq;
 mod joypad;
+mod mbc;
 mod memory;
 mod memory_map;
 mod opcode;

--- a/src/gameboy/opcode.rs
+++ b/src/gameboy/opcode.rs
@@ -1,6 +1,6 @@
 use gameboy::registers;
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Operand {
     None,
     Imm8(u8),

--- a/src/gameboy/registers.rs
+++ b/src/gameboy/registers.rs
@@ -1,4 +1,4 @@
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Registers {
     pub a: u8,
     pub b: u8,
@@ -90,7 +90,7 @@ impl Registers {
     }
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Flags {
     pub zero: bool,
     pub negative: bool,


### PR DESCRIPTION
This PR introduces the concept of memory banking into this emulator and implements two Memory Bank Controllers.

`MBC0` is a ROM-only Memory Bank Controller. It does absolutely no banking at all and reads directly from the ROM stored inside of it. Games like Tetris (that are < 32kb in size) will use this MBC.

`MBC1` is an implementation of the [MBC1 memory bank controller](http://bgb.bircd.org/pandocs.htm#memorybankcontrollers).

Kirby uses an `MBC1` memory bank controller and I have now been successful in getting Kirby's Dream Land to begin rendering:

![kirby-wut](https://user-images.githubusercontent.com/2499070/29776841-54a8cec6-8c4d-11e7-866d-318024198b42.gif)
